### PR TITLE
Added the Ability to Share the App by URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Here are instructions for installing the plugin.  Remember to add this repositor
 
 ### Android
 
-Please note that if you want to share files, you need to setup a `FileProvider` which will give access to the files for sharing with other applications.
+In order to use this plugin, you need to setup a `FileProvider` which will give access to the files for sharing with other applications.
 
 First, add this to AndroidManifest.xml:
 
@@ -32,15 +32,19 @@ Then add the following to `res/xml/file_paths.xml`:
 
 ```aidl
 <paths>
-    <root-path name="root" path="." />`
+    <root-path name="root" path="." />
+    <cache-path name="cache" path="." />
+    <files-path name="files" path="." />
 </paths>
 ```
+
+For the shareAppUrl() method, it uses the file **android/app/src/main/res/mipmap-*/ic_launcher.png** for the image in the sharesheet. Make sure the Flutter app is using the correct image in all the mipmap sizes.
 
 ### iOS
 
 Not supported currently.
 
-## Usage
+## Usage: Sharing the APK
 
 To use the plugin, simply import the library with:
 
@@ -51,7 +55,7 @@ import 'package:share_app/share_app.dart';
 Next, initialize and call the method you want to trigger.  The method is asynchronous so wrap in an async function:
 
 ```aidl
-Future<void> _shareApp() async {
+Future<void> _shareAPK() async {
   final sharePlugin = ShareApp();
   await sharePlugin.shareAPK("Your App Name");
 }
@@ -61,4 +65,31 @@ We also provide an optional parameter to set the name for the file being share. 
 
 ```aidl
 await sharePlugin.shareAPK("Your App Name", apkFileName: "Your APK File Name");
+```
+
+## Usage: Sharing the App URL
+
+We also provide a customized way to share an App URL. It will use ic_launcher.png with a title and url in the sharesheet. In order to support iOS, we recommend installing the [Share +](https://pub.dev/packages/share_plus) package. Then you can use the following code to handle sharing the App URL in both iOS and Android:
+
+```aidl
+import 'dart:io';
+import 'package:share_app/share_app.dart';
+import 'package:share_plus/share_plus.dart';
+...
+Future<void> shareAppUrl(String appName, String url) async {
+  if (!Platform.isAndroid) {
+    final uri = Uri.parse(url);
+    await Share.shareUri(uri);
+    return;
+  }
+  try {
+    /// Try to share the URL with a preview. share_plus does not support this currently.
+    final sharePlugin = ShareApp();
+    sharePlugin.shareAppUrl(appName, url);
+  } catch (e) {
+    /// Fallback to the normal share without preview.
+    final uri = Uri.parse(url);
+    Share.shareUri(uri);
+  }
+}
 ```

--- a/android/src/main/kotlin/com/stories/orality/orality_platform/share_app/ShareAppPlugin.kt
+++ b/android/src/main/kotlin/com/stories/orality/orality_platform/share_app/ShareAppPlugin.kt
@@ -1,5 +1,8 @@
 package com.stories.orality.orality_platform.share_app
 
+import android.content.ClipData
+import android.content.ContentResolver
+import android.content.Intent
 import androidx.annotation.NonNull
 import androidx.core.content.FileProvider
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -11,15 +14,13 @@ import android.net.Uri
 import android.content.pm.PackageManager
 import android.content.pm.PackageInfo
 import android.content.Context
-import android.content.Intent
 import android.os.Build
 import java.io.File
-import java.io.InputStream
-import java.io.OutputStream
 import java.util.HashMap
-
-
-
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import java.io.OutputStream
 
 /** ShareAppPlugin */
 class ShareAppPlugin: FlutterPlugin, MethodCallHandler {
@@ -50,7 +51,17 @@ class ShareAppPlugin: FlutterPlugin, MethodCallHandler {
         result.error("ERROR", "APK URI Missing", null)
         return
       }
-      shareApplication(appApkUri)
+      shareAppAPK(appApkUri)
+      result.success(true)
+    } else if (call.method == "shareAppUrl") {
+      val data: HashMap<String, String> = call.arguments as HashMap<String, String>
+      val title = data.get("title") as? String ?: ""
+      val url = data.get("url") as? String ?: ""
+      if (url.isEmpty()) {
+        result.error("ERROR", "The App url is missing.", null)
+        return
+      }
+      shareAppUrl(title, url)
       result.success(true)
     } else {
       result.notImplemented()
@@ -71,7 +82,7 @@ class ShareAppPlugin: FlutterPlugin, MethodCallHandler {
   //
   // However, that's what the apk_admin library uses, and it seems like the only way to achieve the
   // desired app sharing.
-  private fun shareApplication(appApkUri: Uri) {
+  private fun shareAppAPK(appApkUri: Uri) {
     val shareApp = Intent(Intent.ACTION_SEND)
     shareApp.setDataAndType(appApkUri, "*/*")
     shareApp.putExtra(Intent.EXTRA_STREAM, appApkUri)
@@ -81,32 +92,97 @@ class ShareAppPlugin: FlutterPlugin, MethodCallHandler {
     )
   }
 
+  /**
+   * Shares the app with a title and an image preview.
+   *
+   * @param title The title of the content to be shared.
+   * @param url The URL to be shared.
+   */
+  private fun shareAppUrl(title: String, url: String) {
+    val iconUri: Uri = getAppIconUri()
+    val iconClipData: ClipData = ClipData.newUri(context.contentResolver, null, iconUri)
+    val intent: Intent = Intent().apply {
+      action = Intent.ACTION_SEND
+      putExtra(Intent.EXTRA_TITLE, "$title\n$url")
+      type = "text/plain"
+      clipData = iconClipData
+      flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+      putExtra(Intent.EXTRA_TEXT, url)
+    }
+    context.startActivity(
+      Intent.createChooser(intent, null).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    )
+  }
+
+  /**
+   * Get the app apk file
+   */
   private fun getAppApk(): Uri? {
     val packageManager: PackageManager = context.getPackageManager()
     val packageInfo: PackageInfo = packageManager.getPackageInfo(packageName!!, 0)
     val original = File(packageInfo.applicationInfo.publicSourceDir)
     if (apkFileName.isNullOrEmpty()) {
-      return getUriFromFile(original, context)
+      return getUriFromFile(original)
     }
 
     context.openFileOutput(apkFileName, Context.MODE_PRIVATE).use {
       it.write(original.readBytes())
     }
     val final = File(context.filesDir, apkFileName)
-    return getUriFromFile(final, context)
+    return getUriFromFile(final)
   }
 
-  private fun getUriFromFile(file: File, context: Context): Uri? {
-    val fileUri: Uri
-    fileUri = if (Build.VERSION.SDK_INT >= 24) {
-      // The authority string must match a FileProvider definition in the app's manifest.
-      // See https://developer.android.com/reference/androidx/core/content/FileProvider for
-      // more details.
-      FileProvider.getUriForFile(context, "$packageName.provider", file)
+  /**
+   * Get the app icon and save it to the cached files
+   */
+  private fun getAppIconUri(): Uri {
+    // Dynamically get the resource ID for ic_launcher
+    val resourceId = context.resources.getIdentifier("ic_launcher", "mipmap", context.packageName)
+    if (resourceId == 0) {
+        throw IllegalStateException("Could not find launcher icon in the host app")
+    }
+    // Get the drawable resource
+    val drawable = context.resources.getDrawable(resourceId, context.theme)
+        ?: throw IllegalStateException("Could not load launcher icon")
+    // Convert drawable to bitmap
+    val bitmap = when (drawable) {
+      is BitmapDrawable -> drawable.bitmap
+      else -> {
+        val bitmap = Bitmap.createBitmap(
+          drawable.intrinsicWidth,
+          drawable.intrinsicHeight,
+          Bitmap.Config.ARGB_8888
+        )
+        val canvas = Canvas(bitmap)
+        drawable.setBounds(0, 0, canvas.width, canvas.height)
+        drawable.draw(canvas)
+        bitmap
+      }
+    }
+
+    // Create a file in cache directory
+    val file = File(context.cacheDir, "icon.png")
+    file.outputStream().use { out: OutputStream ->
+      bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+    }
+
+    // Get content URI using FileProvider
+    return getUriFromFile(file)
+  }
+
+  /**
+   * Get the URI from a provided file
+   *
+   * @param file The file to retrieve the URI from
+   *
+   * @return The URI
+   */
+  private fun getUriFromFile(file: File): Uri {
+    return if (Build.VERSION.SDK_INT >= 24) {
+      FileProvider.getUriForFile(context, "${context.packageName}.provider", file)
     } else {
       Uri.fromFile(file)
-    }
-    return fileUri
+    } ?: throw IllegalStateException("Failed to create URI from file: ${file.absolutePath}")
   }
 
 }

--- a/lib/share_app.dart
+++ b/lib/share_app.dart
@@ -2,6 +2,11 @@ import 'share_app_platform_interface.dart';
 
 class ShareApp {
   Future<bool> shareAPK(String packageName, {String apkFileName = ''}) async {
-    return ShareAppPlatform.instance.shareAPK(packageName, apkFileName: apkFileName);
+    return ShareAppPlatform.instance
+        .shareAPK(packageName, apkFileName: apkFileName);
+  }
+
+  Future<bool> shareAppUrl(String title, String url) async {
+    return ShareAppPlatform.instance.shareAppUrl(title, url);
   }
 }

--- a/lib/share_app_method_channel.dart
+++ b/lib/share_app_method_channel.dart
@@ -9,12 +9,35 @@ class MethodChannelShareApp extends ShareAppPlatform {
   @visibleForTesting
   final methodChannel = const MethodChannel('orality_platform.share_app/share');
 
+  /// Share the APK file of the app with the given package name.
+  ///
+  /// [packageName] is the package name of the app whose APK file will be shared.
+  /// [apkFileName] is the name of the APK file to be shared.
+  ///
+  /// Returns true if the APK file was shared successfully, false otherwise.
+  ///
   @override
   Future<bool> shareAPK(String packageName, {String apkFileName = ''}) async {
-    final data = <String, String> {
+    final data = <String, String>{
       'packageName': packageName,
       'apkFileName': apkFileName,
     };
     return await methodChannel.invokeMethod('shareAPK', data);
+  }
+
+  /// Share the app URL with the given title and URL. It gets the icon from the app.
+  ///
+  /// [title] is the title of the app to be shared.
+  /// [url] is the URL of the app to be shared.
+  ///
+  /// Returns true if the app URL was shared successfully, false otherwise.
+  ///
+  @override
+  Future<bool> shareAppUrl(String title, String url) async {
+    final data = <String, String>{
+      'title': title,
+      'url': url,
+    };
+    return await methodChannel.invokeMethod('shareAppUrl', data);
   }
 }

--- a/lib/share_app_platform_interface.dart
+++ b/lib/share_app_platform_interface.dart
@@ -23,7 +23,25 @@ abstract class ShareAppPlatform extends PlatformInterface {
     _instance = instance;
   }
 
+  /// Share the APK file of the app with the given package name.
+  ///
+  /// [packageName] is the package name of the app whose APK file will be shared.
+  /// [apkFileName] is the name of the APK file to be shared.
+  ///
+  /// Returns true if the APK file was shared successfully, false otherwise.
+  ///
   Future<bool> shareAPK(String packageName, {String apkFileName = ''}) {
-    throw UnimplementedError('share() has not been implemented.');
+    throw UnimplementedError('shareAPK() has not been implemented.');
+  }
+
+  /// Share the app URL with the given title and URL. It gets the icon from the app.
+  ///
+  /// [title] is the title of the app to be shared.
+  /// [url] is the URL of the app to be shared.
+  ///
+  /// Returns true if the app URL was shared successfully, false otherwise.
+  ///
+  Future<bool> shareAppUrl(String title, String url) {
+    throw UnimplementedError('shareAppUrl() has not been implemented.');
   }
 }


### PR DESCRIPTION
For OP 2.0, we needed a way to share a URL to the app store for our app. The design needed to show the icon, app name, and link. Added a method that handles this work for Android. iOS can use a plugin like [Share +](https://pub.dev/packages/share_plus).